### PR TITLE
Update Dockerfile invoicing: update version - fix no match for platform in manifest

### DIFF
--- a/microservice-spring-demo/microservice-spring-invoicing/Dockerfile
+++ b/microservice-spring-demo/microservice-spring-invoicing/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:20.0.1_9-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 COPY target/microservice-spring-invoicing-0.0.1-SNAPSHOT.jar .
 CMD java -Xmx300m -Xms300m -XX:TieredStopAtLevel=1 -noverify -jar microservice-spring-invoicing-0.0.1-SNAPSHOT.jar
 EXPOSE 8082

--- a/microservice-spring-demo/microservice-spring-order/Dockerfile
+++ b/microservice-spring-demo/microservice-spring-order/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:20.0.1_9-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 COPY target/microservice-spring-order-0.0.1-SNAPSHOT.jar .
 CMD java -Xmx300m -Xms300m -XX:TieredStopAtLevel=1 -noverify -jar microservice-spring-order-0.0.1-SNAPSHOT.jar
 EXPOSE 8081

--- a/microservice-spring-demo/microservice-spring-shipping/Dockerfile
+++ b/microservice-spring-demo/microservice-spring-shipping/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:20.0.1_9-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 COPY target/microservice-spring-shipping-0.0.1-SNAPSHOT.jar .
 CMD java -Xmx300m -Xms300m -XX:TieredStopAtLevel=1 -noverify -jar microservice-spring-shipping-0.0.1-SNAPSHOT.jar
 EXPOSE 8083


### PR DESCRIPTION
# Changes

changed to version 21 of eclipse temurin

# Error

```shell
failed to solve: eclipse-temurin:20.0.1_9-jre-alpine: no match for platform in manifest 
```

# Log

```shell
=> [spring-order internal] load .dockerignore                                                                      0.0s
=> => transferring context: 2B                                                                                     0.0s
=> [spring-order internal] load build definition from Dockerfile                                                   0.0s
=> => transferring dockerfile: 299B                                                                                0.0s
=> ERROR [spring-order internal] load metadata for docker.io/library/eclipse-temurin:20.0.1_9-jre-alpine           1.8s
=> [spring-order auth] library/eclipse-temurin:pull token for registry-1.docker.io                                 0.0s
------
> [spring-order internal] load metadata for docker.io/library/eclipse-temurin:20.0.1_9-jre-alpine:
------
failed to solve: eclipse-temurin:20.0.1_9-jre-alpine: no match for platform in manifest sha256:3e4249f4c83e69ef6b1fe1a7e868d63ad4c2215a922bef980c0e585a26ad5d7c: not found
```